### PR TITLE
Document graph KPI commands

### DIFF
--- a/LLMS_TXT_UPGRADE_PLAN.md
+++ b/LLMS_TXT_UPGRADE_PLAN.md
@@ -35,9 +35,9 @@ Regenerate or rebuild the artifacts after changes that should be visible to AI t
 
 ## Current Release Context
 
-Latest docs release: `3.20.15` (June 2026).
+Latest docs release: `3.20.16` (June 2026).
 
-Release note: The `worai` CLI installation guide now follows the public installer scripts for macOS/Linux and Windows, with verification steps and `pipx` fallback guidance.
+Release note: The WordLift Cloud `bootstrap.js` FAQ clarifies that the script must not be placed behind cookie consent because it publishes `schema.org` JSON-LD and does not use cookies or similar client-side tracking technologies.
 
 ## Notes
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [x] 2026-06-29 Clarify the WordLift Cloud `bootstrap.js` cookie consent FAQ, refresh the 3.20.16 Version Notice, and bump the docs patch release.
 - [x] 2026-06-18 Align `worai` CLI installation docs with the public installer scripts, refresh the 3.20.15 Version Notice, and bump the docs patch release.
 - [x] 2026-05-28 Add WordLift Cloud CSP guidance for `bootstrap.js`, refresh the 3.20.11 Version Notice, and bump the docs patch release.
 - [x] 2026-05-15 Add canonical Data API documentation for client-side and server-side structured data injection, refresh the 3.20.4 Version Notice, and update project meta docs.

--- a/docs/cloud/index.md
+++ b/docs/cloud/index.md
@@ -108,7 +108,15 @@ Recommended implementation details:
 
 The `bootstrap.js` script does not use cookies or similar client-side tracking technologies and does not store any information in the user's browser.
 
-### 4. Do we share personal data with WordLift?
+### 4. Should bootstrap.js be placed behind cookie consent?
+
+No. The WordLift Cloud script must load on page view so WordLift can inject `schema.org` JSON-LD and Google can parse the structured data.
+
+It is also not necessary to gate it behind cookie consent because `bootstrap.js` does not use cookies or similar client-side tracking technologies and does not store information in the visitor's browser.
+
+For sites that prefer not to rely on client-side injection, WordLift also supports [server-side JSON-LD injection through the Data API](../knowledge-graph/data-api.md#server-side-rendering).
+
+### 5. Do we share personal data with WordLift?
 
 No personally identifiable information is collected through the script. The system records only an anonymized IP address for operational logging purposes. This IP address cannot be linked to an individual and is automatically removed when the log retention period ends.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 import ThemedImage from '@theme/ThemedImage';
 
 :::info Version Notice
-Latest Release: 3.20.15 (June 2026) — Aligned the `worai` CLI installation guide with the public installer scripts, including macOS/Linux and Windows one-liners, verification steps, and `pipx` fallback guidance.
+Latest Release: 3.20.16 (June 2026) — Clarified that the WordLift Cloud `bootstrap.js` script must not be placed behind cookie consent because it publishes `schema.org` JSON-LD and does not use cookies or similar client-side tracking technologies.
 :::
 
 # 👋 Welcome to WordLift

--- a/docs/worai/commands/agent.md
+++ b/docs/worai/commands/agent.md
@@ -1,6 +1,4 @@
----
-title: agent
----
+# agent
 
 Launch external agent CLIs with worai MCP server + skills.
 
@@ -8,54 +6,56 @@ Launch external agent CLIs with worai MCP server + skills.
 - `worai agent [options] [-- <agent-cli-args...>]`
 - `worai agent mcp serve [--config <path>] [--profile <name>]`
 
-Arguments after `--` are passed through to the selected agent CLI unchanged.
-
 ## Options
+- `--agent-cli` / `--cli`: `codex|claude|gemini` (default: `codex`)
+- `--agent-exec`: override executable path
+- `--config`: session default config path for MCP tool calls
+- `--profile`: session default profile for MCP tool calls
+- `--codex-use-user-config`: for `--agent-cli codex`, skip forced WordLift provider/model injection and use existing user Codex auth/config
+- `--dry-run`: print generated launch command and asset paths without launching
+- `--keep-temp`: keep generated temporary skills/MCP config files after exit
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `--agent-cli`, `--cli` | string | `codex` | Agent CLI to launch: `codex|claude|gemini`. |
-| `--agent-exec` | string | auto | Override agent executable path. |
-| `--config` | string | none | Session default `worai.toml` path for MCP tools. |
-| `--profile` | string | none | Session default profile for MCP tools. |
-| `--dry-run` | bool | `false` | Print launch command and generated files without launching. |
-| `--keep-temp` | bool | `false` | Keep generated temporary skill/MCP config files after exit. |
-
-## Codex WordLift model
-By default, `worai agent --agent-cli codex` injects the WordLift provider with `gpt-5-5-graph-sync`.
-
-Override it globally or per profile:
-
-```toml
-[agent]
-codex_model = "gpt-5-5-graph-sync"
-
-[profiles.acme.agent]
-codex_model = "custom-graph-sync"
-```
-
-## MCP tools
-- `worai_version`
-- `worai_help`
-- `worai_graph_validate`
-- `worai_graph_export`
-- `worai_graph_sync_run_start` (async)
-- `worai_structured_data_validate_page`
-- `worai_structured_data_inventory_start` (async)
-- `worai_web_pages_classify_types`
-- `worai_job_status`
-- `worai_job_output`
-- `worai_job_cancel`
-- `worai_cli_exec` (fallback; argv-array based; no shell string)
-
-## Config precedence for MCP calls
-1. per-call `config_path` / `profile`
-2. session defaults from `worai agent --config/--profile`
-3. environment + standard worai discovery
+## Notes
+- `worai agent` generates:
+  - a temporary skills file (`WORAI_SKILL.md`)
+  - a temporary MCP config file pointing to `worai agent mcp serve`
+- MCP tools exposed:
+  - `worai_version`
+  - `worai_help`
+  - `worai_graph_validate`
+  - `worai_graph_export`
+  - `worai_graph_audit`
+  - `worai_graph_kpis`
+  - `worai_entity_matrix`
+  - `worai_graph_reset`
+  - `worai_graph_sync_run_start` (async)
+  - `worai_structured_data_validate_page`
+  - `worai_structured_data_inventory_start` (async)
+  - `worai_web_pages_classify_types`
+  - `worai_job_status`
+  - `worai_job_output`
+  - `worai_job_events`
+  - `worai_job_cancel`
+  - `worai_cli_exec` (fallback; argv-array based)
+- MCP config/profile precedence:
+  - per-call `config_path` + `profile`
+  - then session defaults from `worai agent --config/--profile`
+  - then `WORAI_PROFILE`
+  - then `default`
+- Codex launcher behavior:
+  - default mode injects runtime model config for WordLift provider (`agent.codex_model`, default `gpt-5-5-graph-sync`)
+  - in default mode, `X-API-Key` is resolved from the selected profile `api_key` (with `WORDLIFT_API_KEY` fallback)
+  - in default mode, if no profile is provided, falls back to `default` with a warning
+  - in default mode, exits with a human-readable error when fallback `default` profile is missing in the resolved config
+  - `--codex-use-user-config` disables the forced WordLift provider/model injection and uses existing Codex user auth/config
+  - `--dry-run` redacts `X-API-Key` in printed launch command when injected
+- Config:
+  - set `agent.codex_model` globally or under a profile to override the default Codex WordLift model
 
 ## Examples
 - `worai agent --agent-cli codex`
-- `worai agent --agent-cli codex -- --yolo --search`
+- `worai agent --agent-cli codex --codex-use-user-config`
+- `worai agent --agent-cli codex --config ./worai.toml` (falls back to `default` profile with warning when `--profile` and `WORAI_PROFILE` are not set)
 - `worai agent --agent-cli claude --profile acme`
 - `worai agent --agent-cli gemini --config ./worai.toml --profile acme`
 - `worai agent --agent-cli codex --dry-run`

--- a/docs/worai/commands/graph-kpis.md
+++ b/docs/worai/commands/graph-kpis.md
@@ -1,0 +1,30 @@
+# graph kpis
+
+Calculate graph KPI snapshots from a local RDF export and optionally upload them to the WordLift API.
+
+## Usage
+- `worai graph kpis calculate <file> [--website-host <host>] [--graph-host <host>] [--builtin-shape <name>] [--exclude-builtin-shape <name>] [--shape <file>] [--no-builtin-shapes] [--depth <n>] [--issue-level warning|error] [--shacl-workers <n>] [--output <file>]`
+- `worai graph kpis payload <file> [--snapshot-date YYYY-MM-DD] [--website-host <host>] [--output <file>]`
+- `worai graph kpis push <file> [--snapshot-date YYYY-MM-DD] [--website-host <host>] [--api-url <url>] [--timeout <seconds>] [--output <file>] [--details-output <file>]`
+
+## Notes
+- Requires `wordlift-sdk>=8.3.3`.
+- `<file>` accepts any graph format supported by the SDK graph loader, including Turtle and JSON-LD.
+- `calculate` writes the detailed KPI JSON, including graph totals, URL coverage, duplicate URL groups, rich snippet candidate counts, graph topology, and URL-rooted schema compliance.
+- `payload` writes the numeric-only WordLift API snapshot payload for the selected date.
+- `push` calculates the snapshot, resolves the selected account from the active profile API key, and uploads the dated snapshot to the WordLift API.
+- `--snapshot-date` must use `YYYY-MM-DD`; when omitted, the current UTC date is used.
+- `--website-host` scopes website URL coverage and duplicate URL KPIs to the customer website host.
+- `--graph-host` marks graph dataset hosts as internal when computing broken internal edges; repeat it for multiple hosts.
+- `--depth` controls subgraph expansion for URL-level SHACL compliance. The default is `1`.
+- `--issue-level warning|error` controls whether warnings count as compliance failures. The default is `warning`.
+- `--no-builtin-shapes` runs only shapes passed with `--shape`, useful for fast scheduled KPI gates.
+- `--shacl-workers` parallelizes URL-level SHACL validation.
+- `--output` writes the API payload for `payload` and `push`; it writes the detailed KPI JSON for `calculate`.
+- `--details-output` on `push` writes the detailed KPI JSON from the same calculation used for upload.
+
+## Examples
+- `worai --profile acme graph kpis calculate ./acme-export.ttl --website-host www.example.com --output graph-kpis.json`
+- `worai --profile acme graph kpis payload ./acme-export.ttl --snapshot-date 2026-06-29 --website-host www.example.com --output graph-kpi-payload.json`
+- `worai --profile acme graph kpis push ./acme-export.ttl --snapshot-date 2026-06-29 --website-host www.example.com --shacl-workers 4 --output graph-kpi-payload.json --details-output graph-kpis.json`
+- `worai --profile acme graph kpis push ./acme-export.ttl --snapshot-date 2026-06-29 --website-host www.example.com --no-builtin-shapes --shape profiles/_base/shapes/graph-kpis-url-roots.shacl.ttl --output graph-kpi-payload.json --details-output graph-kpis.json`

--- a/docs/worai/commands/graph.md
+++ b/docs/worai/commands/graph.md
@@ -1,25 +1,31 @@
----
-title: graph
----
-
 # graph
 
 Run graph-specific workflows.
+
+Mapping docs:
+- Reference: `docs/graph-sync-mappings-reference.md`
+- Guide: `docs/graph-sync-mappings-guide.md`
+- Examples: `docs/graph-sync-mappings-examples.md`
 
 ## Usage
 - `worai graph sync run [--debug]`
 - `worai --config <path> --profile <name> graph sync run [--debug]`
 - `worai graph sync create <destination> [--template <src>] [--defaults] [--data-file <path>] [--vcs-ref <ref>] [--non-interactive] [--force]`
-- `worai graph export [output_file_name]`
+- `worai graph export [--validate] [output_file_name]`
 - `worai graph validate <file-or-url> [<file-or-url> ...] [--builtin-shape <name>] [--exclude-builtin-shape <name>] [--shape <file-or-url>] [--level warning|error] [--format text|json]`
 - `worai graph property delete <predicate> [--dry-run] [--yes] [--workers <n>] [--retries <n>] [--rate-delay <s>] [--limit <n>]`
+- `worai graph audit <file> [--depth <n>] [--list-isolated-iris] [--show-url-violations] [--rich-snippets-granularity counts|entities] [--workers <n>] [--builtin-shape <name>] [--exclude-builtin-shape <name>] [--shape <file>] [--issue-level warning|error] [--format text|json]`
+- `worai graph kpis calculate <file> [--website-host <host>] [--graph-host <host>] [--builtin-shape <name>] [--exclude-builtin-shape <name>] [--shape <file>] [--no-builtin-shapes] [--depth <n>] [--issue-level warning|error] [--shacl-workers <n>] [--output <file>]`
+- `worai graph kpis payload <file> [--snapshot-date YYYY-MM-DD] [--website-host <host>] [--output <file>]`
+- `worai graph kpis push <file> [--snapshot-date YYYY-MM-DD] [--website-host <host>] [--api-url <url>] [--timeout <seconds>] [--output <file>] [--details-output <file>]`
+- `worai graph reset [--keep-country] [--keep-language] [--keep-url] [--yes]`
 
 ## Notes
 - `graph sync run` executes the graph sync workflow for a profile in `worai.toml`.
 - `graph sync create` bootstraps a new graph sync project from a Copier template.
 - `graph sync create` enables Copier trusted mode by default, so template `_tasks` run automatically.
-- `graph export` downloads graph data from `/export` and writes it to a local file.
-  - `--profile` is optional for export and defaults to `default`.
+- `graph export` downloads graph data from `/dataset/export` and writes it to a local file.
+  - profile resolution is: root `--profile`, then `WORAI_PROFILE`, then `default`.
   - API key resolution is `profiles.<name>.api_key` first, then `WORDLIFT_API_KEY`.
   - output format is inferred from file extension:
     - `.ttl` -> `text/turtle`
@@ -28,28 +34,32 @@ Run graph-specific workflows.
     - `.rdf`/`.xml` -> `application/rdf+xml`
     - `.jsonld`/`.json` -> `application/ld+json`
   - when no output file is passed, default name is `export_<profile>_<yyyyMMdd>_<seq>.ttl` (sequence starts at `1` and increments if the file already exists).
-- `graph validate` validates one or more local files or URLs with SHACL shapes.
+  - `--validate` runs SHACL validation on the exported file right after download; the command fails on SHACL errors or warnings.
+- `graph validate` validates one or more local files or URLs.
   - `--builtin-shape` includes selected packaged shape names.
   - `--exclude-builtin-shape` removes packaged shapes from the active set.
   - `--shape` adds extra shape files/URLs.
-  - `--level warning|error` controls failure threshold.
-  - `--format text|json` selects output format.
+  - `--level warning|error` controls failure threshold (`warning` fails on warnings+errors, `error` fails only on errors).
+  - `--format text|json` selects report output format.
 - `graph property delete` removes one predicate from all matching entities.
   - accepts full IRI (`https://w3id.org/seovoc/html`) or CURIE (`seovoc:html`).
   - includes private fields by default (`X-include-Private: true`) for both matching-entity discovery and deletion PATCH requests.
   - `--dry-run` reports matching entities without patching.
   - without `--yes`, the command asks for confirmation before patching.
+- `--non-interactive` is implemented by enabling Copier defaults mode and skipping prompts; required unanswered fields still fail fast.
 - Supported input sources:
   - `urls` (explicit URL list)
   - `sitemap_url` (+ optional `sitemap_url_pattern`)
   - Google Sheets (`sheets_url` + `sheets_name` + `sheets_service_account`)
   - configure exactly one source mode per run.
 - `graph sync run` profile resolution is: root `--profile`, then `WORAI_PROFILE`, then `default`.
-- `graph sync run` profile resolution is: command `--profile` (deprecated), then root `--profile`, then `WORAI_PROFILE`, then `default`.
 - Config path comes from root `worai --config ...` when provided.
-- Without root `--config`, standard worai config discovery applies (`WORAI_CONFIG`, `./worai.toml`, `~/.config/worai/config.toml`, `~/.worai.toml`).
+- Without root `--config`, standard worai config discovery applies (`WORAI_CONFIG`, nearest `worai.toml` from current directory upward, `~/.config/worai/config.toml`, `~/.worai.toml`).
+- `.env` is auto-loaded at CLI startup; a `WORAI_CONFIG` value from `.env` is honored unless `WORAI_CONFIG` is already set in the environment.
+- Logging precedence is: root `--log-level`, then `WORAI_LOG_LEVEL`, then `profiles.<name>.log_level`, then `profiles._base.log_level`, then global `log_level`, then `info`.
+- During `graph sync run`, the resolved effective level is propagated to `morph-kgc` as `logging_level` so `warning` suppresses morph `INFO` logs (for example `mapping_partitioner`) while `info` allows them.
 - `sheets_service_account` accepts either inline JSON or a file path.
-- The command fails when the selected profile does not define `api_key`.
+- The command fails if the selected profile has no `api_key`.
 - `google_search_console` can be set globally or per profile in `worai.toml`.
   - profile value overrides global value.
   - default is `false` when unset.
@@ -59,18 +69,30 @@ Run graph-specific workflows.
   - accepted values: `oneshot`, `persistent`.
   - SDK 6 default is `persistent`; set `oneshot` to preserve legacy one-shot behavior.
   - when set, exported as env var `POSTPROCESSOR_RUNTIME` during `graph sync run`.
+- `canonical_id_strategy` can be set globally or per profile in `worai.toml` (requires SDK 6.12.3+).
+  - profile value overrides global value.
+  - accepted values: `legacy` (default), `dependency_graph`.
+  - forwarded to the SDK as `CANONICAL_ID_STRATEGY` via `extra_settings`.
+  - use `dependency_graph` when postprocessors mint FAQ child entities (e.g. an Article also typed as FAQPage with Question nodes via `schema:mainEntity`) before canonical IRIs are finalized; `legacy` mode leaves those questions under the stale pre-canonical root IRI.
+  - can also be set via env var `CANONICAL_ID_STRATEGY=dependency_graph`.
 - Callback telemetry for `graph sync run`:
   - `graph sync run` uses `run_cloud_workflow` and logs per-graph progress events and one final KPI summary.
   - `on_info` lifecycle messages remain supported and are logged as info events.
   - debug artifacts are written by the SDK protocol callback to `output/debug_cloud/<profile>/` (relative to the invocation current working directory):
     - `static_templates.ttl`
     - `cloud_<sha256(url)>.ttl` for each callback URL.
-- SDK 6 ingestion settings are forwarded when configured:
+- SDK `wordlift-sdk` 5.1.1+ postprocessor context changes:
+  - `context.settings` removed; read from `context.profile` (example: `context.profile["settings"]["api_url"]`).
+  - `context.account.key` removed; use `context.account_key`.
+  - `context.account` remains the clean `/me` account object.
+- `web_page_import_timeout` in `worai.toml` is interpreted as seconds and converted to milliseconds for the SDK.
+  - example: `web_page_import_timeout = 60` -> `60000` ms
+  - explicit suffixes are also supported: `60s`, `60000ms`
+- SDK 6 ingestion settings are forwarded when present:
   - `ingest_source`: `auto|urls|sitemap|sheets|local`
   - `ingest_loader`: `auto|simple|proxy|playwright|premium_scraper|web_scrape_api|passthrough`
   - `ingest_passthrough_when_html`: default `true`
 - With `wordlift-sdk>=6.10.0`, `ingest_timeout_ms` defaults to `30000` in the SDK and is forwarded as `INGEST_TIMEOUT_MS` only when explicitly configured in worai.
-- With `wordlift-sdk>=6.10.0`, `playwright_wait_until` defaults to `domcontentloaded` in the SDK and is forwarded as `PLAYWRIGHT_WAIT_UNTIL` only when explicitly configured in worai.
 - SDK 6 cloud-flow migration deprecates integration reliance on:
   - `WEB_PAGE_IMPORT_MODE`
   - `WEB_PAGE_IMPORT_TIMEOUT`
@@ -78,6 +100,7 @@ Run graph-specific workflows.
   - use `shacl_validate_mode = "warn"|"fail"|"off"`
   - use `shacl_builtin_shapes`, `shacl_exclude_builtin_shapes`, `shacl_extra_shapes`
   - `shacl_validate_sync` and `shacl_shape_specs` are no longer supported
+
 Example ingestion config:
 ```toml
 [profiles.acme]
@@ -100,20 +123,65 @@ Example profile config:
 [profiles.acme]
 api_key = "wl_..."
 google_search_console = true
+postprocessor_runtime = "persistent"
+canonical_id_strategy = "dependency_graph"
 sheets_service_account = "./service-account.json"
 # or inline JSON string:
 # sheets_service_account = "{\"type\":\"service_account\",...}"
 ```
+
+- `graph audit` audits a local RDF file for schema compliance, rich snippets coverage, and graph connectivity (requires wordlift-sdk>=6.11.0).
+  - `<file>` accepts TTL, JSON-LD, NT, or RDF/XML.
+  - `--depth <n>` controls subgraph expansion depth for schema compliance checks (default: 1).
+  - `--list-isolated-iris` includes the IRI list for each isolated subgraph in the report.
+  - `--show-url-violations` lists each failing URL with its SHACL violations.
+  - `--rich-snippets-granularity counts|entities` controls detail level of rich snippets section (default: counts).
+  - `--workers <n>` sets max worker processes for SHACL validation (default: auto).
+  - `--builtin-shape` and `--exclude-builtin-shape` are mutually exclusive.
+  - `--shape <file>` appends an extra local `.ttl` shape file; repeat for multiple.
+  - `--issue-level warning|error` filters the issue severity shown (default: warning).
+  - `--format text|json` selects report output format (default: text).
+  - exits with code 1 if load errors are encountered.
+- `graph kpis` calculates compact graph KPI snapshots from a local RDF export (requires wordlift-sdk>=8.3.3).
+  - `calculate` writes the detailed KPI JSON for inspection or artifacts.
+  - `payload` writes the numeric-only WordLift API payload for a dated snapshot.
+  - `push` calculates the snapshot, resolves the selected account through the WordLift API, and uploads with `PUT /accounts/{id}/graph-kpis/{snapshot_date}`.
+  - `--website-host` scopes URL coverage and duplicate URL KPIs to the customer website host.
+  - `--graph-host` marks graph dataset hosts as internal when computing broken internal edges; repeat for multiple hosts.
+  - URL-rooted SHACL compliance validates first-level entities with `schema:url` at `--depth 1` by default.
+  - `--no-builtin-shapes` runs only shapes passed with `--shape`, useful for fast scheduled KPI gates.
+  - `--shacl-workers` parallelizes URL-level SHACL validation for larger graphs.
+  - `--details-output` on `push` writes the detailed KPI snapshot without recalculating.
+- `graph reset` resets the WordLift account associated with the current profile (requires wordlift-sdk>=6.12.0).
+  - **Destructive and irreversible** — prompts for confirmation unless `--yes` is passed.
+  - `--keep-country` preserves the account country on reset.
+  - `--keep-language` preserves the account language on reset.
+  - `--keep-url` preserves the account URL on reset.
+  - API key is resolved from the active profile (`profiles.<name>.api_key`) or `WORDLIFT_API_KEY`.
 
 ## Examples
 - `worai --profile acme graph sync run`
 - `worai --config ./worai.toml --profile acme graph sync run`
 - `worai --profile acme graph sync run --debug`
 - `worai graph sync create ./acme-graph`
+- `worai graph sync create ./acme-graph --template ./graph-sync-template`
+- `worai graph sync create ./acme-graph --data-file ./answers.yml --non-interactive`
+- `worai graph sync create ./acme-graph --vcs-ref v1.2.3`
 - `worai graph export`
 - `worai --profile acme graph export`
-- `worai graph export ./acme-export.jsonld --profile acme`
+- `worai --profile acme graph export ./acme-export.jsonld`
+- `worai graph export ./acme-export.ttl --validate`
 - `worai graph validate ./acme-export.ttl`
-- `worai graph validate ./acme-export.ttl ./acme-export.jsonld --builtin-shape google-required --shape ./custom.ttl --level warning --format json`
+- `worai graph validate ./acme-export.ttl ./acme-export.jsonld --builtin-shape google-required --exclude-builtin-shape schemaorg-grammar --shape ./custom.ttl --level warning --format json`
 - `worai graph property delete seovoc:html --dry-run`
 - `worai graph property delete https://w3id.org/seovoc/html --yes --workers 4`
+- `worai graph audit ./acme-export.ttl`
+- `worai graph audit ./acme-export.ttl --format json --show-url-violations`
+- `worai graph audit ./acme-export.ttl --rich-snippets-granularity entities --issue-level error`
+- `worai graph audit ./acme-export.ttl --builtin-shape google-required --shape ./custom.ttl`
+- `worai --profile acme graph kpis calculate ./acme-export.ttl --website-host www.example.com --output graph-kpis.json`
+- `worai --profile acme graph kpis payload ./acme-export.ttl --snapshot-date 2026-06-29 --website-host www.example.com --output graph-kpi-payload.json`
+- `worai --profile acme graph kpis push ./acme-export.ttl --snapshot-date 2026-06-29 --website-host www.example.com --shacl-workers 4 --output graph-kpi-payload.json --details-output graph-kpis.json`
+- `worai --profile acme graph kpis push ./acme-export.ttl --snapshot-date 2026-06-29 --website-host www.example.com --no-builtin-shapes --shape profiles/_base/shapes/graph-kpis-url-roots.shacl.ttl --output graph-kpi-payload.json --details-output graph-kpis.json`
+- `worai --profile acme graph reset --yes`
+- `worai --profile acme graph reset --keep-country --keep-language`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "3.20.15",
+  "version": "3.20.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "3.20.15",
+      "version": "3.20.16",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/plugin-client-redirects": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "3.20.15",
+  "version": "3.20.16",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/sidebars.js
+++ b/sidebars.js
@@ -260,6 +260,7 @@ const sidebars = {
                 "worai/commands/find-missing-names",
                 "worai/commands/find-url-by-type",
                 "worai/commands/graph",
+                "worai/commands/graph-kpis",
                 "worai/commands/link-groups",
                 "worai/commands/patch",
                 "worai/commands/self",


### PR DESCRIPTION
## Summary

Publishes documentation for the graph KPI commands and MCP tool.

## Changes

- Add `worai/commands/graph-kpis` page.
- Update `graph` command docs with KPI usage and examples.
- Add `worai_graph_kpis` to the agent MCP tools list.
- Add the graph KPI page to the docs sidebar.

## Validation

- `git diff --check`

## Related PRs

- SDK snapshot API: https://github.com/wordlift/python-sdk/pull/27
- worai CLI/API push: https://github.com/wordlift/worai/pull/22
- BusesForSale workflow: https://github.com/graph-sync/graph-sync-busesforsale-com/pull/1
